### PR TITLE
fix afk watcher duplicate events causing incorrect data

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,10 +202,12 @@ You can query data directly in the ActivityWatch ui:
 ### Example Query: Stopwatch Data (filtered by AFK status)
 
 ```sh
-afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
-window_events = query_bucket(find_bucket("aw-stopwatch"));
-window_events = filter_period_intersect(window_events, filter_keyvals(afk_events, "status", ["not-afk"]));
-RETURN = sort_by_duration(window_events);
+all_stopwatch_events = query_bucket(find_bucket("aw-stopwatch"));
+all_afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
+deduped_flooded_afk = flood(all_afk_events);
+filtered_afk_events = filter_keyvals(deduped_flooded_afk, "status", ["not-afk"]);
+working_events = filter_period_intersect(all_stopwatch_events, filtered_afk_events);
+RETURN = sort_by_timestamp(working_events);
 ```
 
 

--- a/src/resources/index.html
+++ b/src/resources/index.html
@@ -46,10 +46,12 @@
             // query stopwatch events intersecting with not-afk
             // note: expects ?start=...&end=... in the url
             const ranges = ( start && end ) ? [ `${ start }/${ end }` ] : [ '' ];
-            const q = `afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
-                stop_events = query_bucket(find_bucket("aw-stopwatch"));
-                stop_events = filter_period_intersect(stop_events, filter_keyvals(afk_events, "status", ["not-afk"]));
-                RETURN = sort_by_duration(stop_events);`;
+            const q = `all_stopwatch_events = query_bucket(find_bucket("aw-stopwatch"));
+                all_afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
+                deduped_flooded_afk = flood(all_afk_events);
+                filtered_afk_events = filter_keyvals(deduped_flooded_afk, "status", ["not-afk"]);
+                working_events = filter_period_intersect(all_stopwatch_events, filtered_afk_events);
+                RETURN = sort_by_timestamp(working_events);`;
             try {
                 const resp = await client.query( ranges, [ q ] );
                 return Array.isArray( resp ) ? resp[ 0 ] : [];

--- a/src/resources/index.js
+++ b/src/resources/index.js
@@ -292,10 +292,12 @@ function stringHashToColor(str){
 // const end = urlParams.get( 'end' );
 // // 
 // const client = new AWClient( 'aw-custom-viz', { baseURL: window.location.origin } );
-// const DEFAULT_AWQUERY = `afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
-//     stop_events = query_bucket(find_bucket("aw-stopwatch"));
-//     stop_events = filter_period_intersect(stop_events, filter_keyvals(afk_events, "status", ["not-afk"]));
-//     RETURN = sort_by_duration(stop_events);`;
+// const DEFAULT_AWQUERY = `all_stopwatch_events = query_bucket(find_bucket("aw-stopwatch"));
+//     all_afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
+//     deduped_flooded_afk = flood(all_afk_events);
+//     filtered_afk_events = filter_keyvals(deduped_flooded_afk, "status", ["not-afk"]);
+//     working_events = filter_period_intersect(all_stopwatch_events, filtered_afk_events);
+//     RETURN = sort_by_timestamp(working_events);`;
 // async function queryActivityWatchData (query) {
 //     // query stopwatch events intersecting with not-afk
 //     // note: expects ?start=...&end=... in the url

--- a/src/visualizations/aw-stopwatch-bars/index.html
+++ b/src/visualizations/aw-stopwatch-bars/index.html
@@ -46,10 +46,12 @@
             // query stopwatch events intersecting with not-afk
             // note: expects ?start=...&end=... in the url
             const ranges = ( start && end ) ? [ `${ start }/${ end }` ] : [ '' ];
-            const q = `afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
-                stop_events = query_bucket(find_bucket("aw-stopwatch"));
-                stop_events = filter_period_intersect(stop_events, filter_keyvals(afk_events, "status", ["not-afk"]));
-                RETURN = sort_by_duration(stop_events);`;
+            const q = `all_stopwatch_events = query_bucket(find_bucket("aw-stopwatch"));
+                all_afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
+                deduped_flooded_afk = flood(all_afk_events);
+                filtered_afk_events = filter_keyvals(deduped_flooded_afk, "status", ["not-afk"]);
+                working_events = filter_period_intersect(all_stopwatch_events, filtered_afk_events);
+                RETURN = sort_by_timestamp(working_events);`;
             try {
                 const resp = await client.query( ranges, [ q ] );
                 return Array.isArray( resp ) ? resp[ 0 ] : [];

--- a/src/visualizations/aw-stopwatch-bars/index.js
+++ b/src/visualizations/aw-stopwatch-bars/index.js
@@ -292,10 +292,12 @@ function stringHashToColor(str){
 // const end = urlParams.get( 'end' );
 // // 
 // const client = new AWClient( 'aw-custom-viz', { baseURL: window.location.origin } );
-// const DEFAULT_AWQUERY = `afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
-//     stop_events = query_bucket(find_bucket("aw-stopwatch"));
-//     stop_events = filter_period_intersect(stop_events, filter_keyvals(afk_events, "status", ["not-afk"]));
-//     RETURN = sort_by_duration(stop_events);`;
+// const DEFAULT_AWQUERY = `all_stopwatch_events = query_bucket(find_bucket("aw-stopwatch"));
+//     all_afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
+//     deduped_flooded_afk = flood(all_afk_events);
+//     filtered_afk_events = filter_keyvals(deduped_flooded_afk, "status", ["not-afk"]);
+//     working_events = filter_period_intersect(all_stopwatch_events, filtered_afk_events);
+//     RETURN = sort_by_timestamp(working_events);`;
 // async function queryActivityWatchData (query) {
 //     // query stopwatch events intersecting with not-afk
 //     // note: expects ?start=...&end=... in the url

--- a/src/visualizations/aw-stopwatch-pie/index.html
+++ b/src/visualizations/aw-stopwatch-pie/index.html
@@ -46,10 +46,12 @@
             // query stopwatch events intersecting with not-afk
             // note: expects ?start=...&end=... in the url
             const ranges = ( start && end ) ? [ `${ start }/${ end }` ] : [ '' ];
-            const q = `afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
-                stop_events = query_bucket(find_bucket("aw-stopwatch"));
-                stop_events = filter_period_intersect(stop_events, filter_keyvals(afk_events, "status", ["not-afk"]));
-                RETURN = sort_by_duration(stop_events);`;
+            const q = `all_stopwatch_events = query_bucket(find_bucket("aw-stopwatch"));
+                all_afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
+                deduped_flooded_afk = flood(all_afk_events);
+                filtered_afk_events = filter_keyvals(deduped_flooded_afk, "status", ["not-afk"]);
+                working_events = filter_period_intersect(all_stopwatch_events, filtered_afk_events);
+                RETURN = sort_by_timestamp(working_events);`;
             try {
                 const resp = await client.query( ranges, [ q ] );
                 return Array.isArray( resp ) ? resp[ 0 ] : [];

--- a/src/visualizations/aw-stopwatch-pie/index.js
+++ b/src/visualizations/aw-stopwatch-pie/index.js
@@ -292,10 +292,12 @@ function stringHashToColor(str){
 // const end = urlParams.get( 'end' );
 // // 
 // const client = new AWClient( 'aw-custom-viz', { baseURL: window.location.origin } );
-// const DEFAULT_AWQUERY = `afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
-//     stop_events = query_bucket(find_bucket("aw-stopwatch"));
-//     stop_events = filter_period_intersect(stop_events, filter_keyvals(afk_events, "status", ["not-afk"]));
-//     RETURN = sort_by_duration(stop_events);`;
+// const DEFAULT_AWQUERY = `all_stopwatch_events = query_bucket(find_bucket("aw-stopwatch"));
+//     all_afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
+//     deduped_flooded_afk = flood(all_afk_events);
+//     filtered_afk_events = filter_keyvals(deduped_flooded_afk, "status", ["not-afk"]);
+//     working_events = filter_period_intersect(all_stopwatch_events, filtered_afk_events);
+//     RETURN = sort_by_timestamp(working_events);`;
 // async function queryActivityWatchData (query) {
 //     // query stopwatch events intersecting with not-afk
 //     // note: expects ?start=...&end=... in the url

--- a/src/visualizations/aw-stopwatch-timeline/index.html
+++ b/src/visualizations/aw-stopwatch-timeline/index.html
@@ -46,10 +46,12 @@
             // query stopwatch events intersecting with not-afk
             // note: expects ?start=...&end=... in the url
             const ranges = ( start && end ) ? [ `${ start }/${ end }` ] : [ '' ];
-            const q = `afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
-                stop_events = query_bucket(find_bucket("aw-stopwatch"));
-                stop_events = filter_period_intersect(stop_events, filter_keyvals(afk_events, "status", ["not-afk"]));
-                RETURN = sort_by_duration(stop_events);`;
+            const q = `all_stopwatch_events = query_bucket(find_bucket("aw-stopwatch"));
+                all_afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
+                deduped_flooded_afk = flood(all_afk_events);
+                filtered_afk_events = filter_keyvals(deduped_flooded_afk, "status", ["not-afk"]);
+                working_events = filter_period_intersect(all_stopwatch_events, filtered_afk_events);
+                RETURN = sort_by_timestamp(working_events);`;
             try {
                 const resp = await client.query( ranges, [ q ] );
                 return Array.isArray( resp ) ? resp[ 0 ] : [];

--- a/src/visualizations/aw-stopwatch-timeline/index.js
+++ b/src/visualizations/aw-stopwatch-timeline/index.js
@@ -292,10 +292,12 @@ function stringHashToColor(str){
 // const end = urlParams.get( 'end' );
 // // 
 // const client = new AWClient( 'aw-custom-viz', { baseURL: window.location.origin } );
-// const DEFAULT_AWQUERY = `afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
-//     stop_events = query_bucket(find_bucket("aw-stopwatch"));
-//     stop_events = filter_period_intersect(stop_events, filter_keyvals(afk_events, "status", ["not-afk"]));
-//     RETURN = sort_by_duration(stop_events);`;
+// const DEFAULT_AWQUERY = `all_stopwatch_events = query_bucket(find_bucket("aw-stopwatch"));
+//     all_afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
+//     deduped_flooded_afk = flood(all_afk_events);
+//     filtered_afk_events = filter_keyvals(deduped_flooded_afk, "status", ["not-afk"]);
+//     working_events = filter_period_intersect(all_stopwatch_events, filtered_afk_events);
+//     RETURN = sort_by_timestamp(working_events);`;
 // async function queryActivityWatchData (query) {
 //     // query stopwatch events intersecting with not-afk
 //     // note: expects ?start=...&end=... in the url

--- a/src/visualizations/aw-stopwatch-tree/index.html
+++ b/src/visualizations/aw-stopwatch-tree/index.html
@@ -46,10 +46,12 @@
             // query stopwatch events intersecting with not-afk
             // note: expects ?start=...&end=... in the url
             const ranges = ( start && end ) ? [ `${ start }/${ end }` ] : [ '' ];
-            const q = `afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
-                stop_events = query_bucket(find_bucket("aw-stopwatch"));
-                stop_events = filter_period_intersect(stop_events, filter_keyvals(afk_events, "status", ["not-afk"]));
-                RETURN = sort_by_duration(stop_events);`;
+            const q = `all_stopwatch_events = query_bucket(find_bucket("aw-stopwatch"));
+                all_afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
+                deduped_flooded_afk = flood(all_afk_events);
+                filtered_afk_events = filter_keyvals(deduped_flooded_afk, "status", ["not-afk"]);
+                working_events = filter_period_intersect(all_stopwatch_events, filtered_afk_events);
+                RETURN = sort_by_timestamp(working_events);`;
             try {
                 const resp = await client.query( ranges, [ q ] );
                 return Array.isArray( resp ) ? resp[ 0 ] : [];

--- a/src/visualizations/aw-stopwatch-tree/index.js
+++ b/src/visualizations/aw-stopwatch-tree/index.js
@@ -292,10 +292,12 @@ function stringHashToColor(str){
 // const end = urlParams.get( 'end' );
 // // 
 // const client = new AWClient( 'aw-custom-viz', { baseURL: window.location.origin } );
-// const DEFAULT_AWQUERY = `afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
-//     stop_events = query_bucket(find_bucket("aw-stopwatch"));
-//     stop_events = filter_period_intersect(stop_events, filter_keyvals(afk_events, "status", ["not-afk"]));
-//     RETURN = sort_by_duration(stop_events);`;
+// const DEFAULT_AWQUERY = `all_stopwatch_events = query_bucket(find_bucket("aw-stopwatch"));
+//     all_afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
+//     deduped_flooded_afk = flood(all_afk_events);
+//     filtered_afk_events = filter_keyvals(deduped_flooded_afk, "status", ["not-afk"]);
+//     working_events = filter_period_intersect(all_stopwatch_events, filtered_afk_events);
+//     RETURN = sort_by_timestamp(working_events);`;
 // async function queryActivityWatchData (query) {
 //     // query stopwatch events intersecting with not-afk
 //     // note: expects ?start=...&end=... in the url


### PR DESCRIPTION
## PR Summary

I’m seeing overlapping `aw-watcher-afk` events with the same status but different durations. These overlapping/duplicate events lead to incorrect downstream results. I assumed overlapping events from the same watcher would be merged by default (or deduped), but that doesn’t seem to be the case so im testing a new query(below). 

The activitywatch [docs under magic variables](https://docs.activitywatch.net/en/latest/examples/working-with-data.html#magic-variables) use flood in their examples, which according to [the source](https://docs.activitywatch.net/en/latest/_modules/aw_transform/flood.html#flood) merges overlapping sections they call "negative gaps". Im not sure if this is a bandaid or intended bahavior as its unclear from the docs but either way its not useful for accurate time tracking. 

## current query
```aw-query
afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
stop_events = query_bucket(find_bucket("aw-stopwatch"));
stop_events = filter_period_intersect(stop_events, filter_keyvals(afk_events, "status", ["not-afk"]));
RETURN = sort_by_duration(stop_events);
```

## new query
```aw-query
all_stopwatch_events = query_bucket(find_bucket("aw-stopwatch"));
all_afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
deduped_flooded_afk = flood(all_afk_events);
filtered_afk_events = filter_keyvals(deduped_flooded_afk, "status", ["not-afk"]);
working_events = filter_period_intersect(all_stopwatch_events, filtered_afk_events);
RETURN = sort_by_timestamp(working_events);
```